### PR TITLE
Improve caching during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ COPY kodi_init /sbin/kodi_init
 
 RUN useradd -m -u 10000 kodi && \
     chown kodi. -R /config && \
-    ln -s /config /usr/share/kodi/portable_data
+    ln -s /config /usr/local/share/kodi/portable_data
 
 VOLUME /config
 WORKDIR /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## Download, Unpack, Patch Kodi source
 FROM alpine AS source
 
 RUN apk add --no-cache curl git ca-certificates tar
@@ -13,6 +14,8 @@ WORKDIR /usr/src/kodi
 COPY kodi-headless.patch .
 RUN git apply *.patch
 
+## Prepare base for final image, and build image.
+## They share common files and installed packages.
 FROM debian:stretch AS base
 COPY dpkg_excludes /etc/dpkg/dpkg.cfg.d/excludes
 


### PR DESCRIPTION
This improves caching even if build stage is completely rewritten. The commands have been re-ordered to improve caching and prevent extra repeated downloads.

Commit messages explain the best.