### PR TITLE
Add option to use custom advancedsettings.xml instead of built-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Container environment variables:
 * `KODI_CLEAN` - Whether to clean up the library periodically [`true`/`false`] (optional, requires sources.xml to be present)
 * `KODI_CLEAN_INTERVAL` - How often to clean up the library in seconds (optional, default is 86400 [1 day])
 
+## Automatic library cleaning
 
 If you want to enable automatic library cleaning you HAVE to create an appropriate sources.xml (or grab a copy from you main HTPC)
 ```bash
@@ -72,6 +73,23 @@ and enable library cleaning via the respective flag:
 ```
 
 __WARNING__: A misconfigured sources.xml can lead to the Kodi instance not finding any of your media which will result in emtpying your database. Make a backup of your database and/or be double sure of the sources.xml before enabling this feature!
+
+## Custom advancedsettings.xml
+
+If you want to supply a custom advancedsettings.xml, make sure the file is readable by uid 10000 and mount it read-only, e.g.:
+```bash
+-v /path/to/advancedsettings.xml:/config/userdata/advancedsettings.xml:ro
+```
+See advancedsettings.xml.default for the container's defaults. Make sure to add appropriate values for
+```xml
+<videodatabase>
+    ...
+</videodatabase>
+<musicdatabase>
+    ...
+</musicdatabase>
+```
+as `KODI_DBHOST`, `KODI_DBUSER` and `KODI_DBPASS` can't be applied when the file is read-only.
 
 # Credits
 

--- a/kodi_init
+++ b/kodi_init
@@ -3,13 +3,22 @@
 set -e
 trap 'kill $(jobs -p) 2>/dev/null' EXIT
 
-cp /usr/local/share/kodi/advancedsettings.xml.default /config/userdata/advancedsettings.xml
-chown kodi. /config/userdata/advancedsettings.xml
+default_advancedsettings=true
+cp /usr/local/share/kodi/advancedsettings.xml.default /config/userdata/advancedsettings.xml || {
+  default_advancedsettings=false
+  echo "Change ownership of /config/userdata/advancedsettings.xml: NO (file is mounted read-only)"
+}
+if [ "$default_advancedsettings" = true ]; then
+  echo "Change ownership of /config/userdata/advancedsettings.xml: YES"
+  chown kodi. /config/userdata/advancedsettings.xml
+fi
 
 echo "======================================================="
 
-if [ ! -z $KODI_DBHOST ] && [ ! -z $KODI_DBUSER ] && [ ! -z $KODI_DBPASS ]; then
-  echo "Shared MySQL database: YES"
+if [ "$default_advancedsettings" = false ]; then
+  echo "Overwrite MySQL settings: NO (/config/userdata/advancedsettings.xml is mounted read-only)"
+elif [ ! -z $KODI_DBHOST ] && [ ! -z $KODI_DBUSER ] && [ ! -z $KODI_DBPASS ]; then
+  echo "Overwrite MySQL settings: YES"
   sed -i -e "s/\(<host>\)\([^<]*\)\(<[^>]*\)/\1$KODI_DBHOST\3/g" /config/userdata/advancedsettings.xml
   sed -i -e "s/\(<user>\)\([^<]*\)\(<[^>]*\)/\1$KODI_DBUSER\3/g" /config/userdata/advancedsettings.xml
   sed -i -e "s/\(<pass>\)\([^<]*\)\(<[^>]*\)/\1$KODI_DBPASS\3/g" /config/userdata/advancedsettings.xml


### PR DESCRIPTION
This PR adds the option to not overwrite /config/userdata/advancedsettings.xml.

I'd like to add some settings to the advancedsettings.xml like excluded directories. An alternative specifying a completely custom advancedsettings.xml would be to merge the default one with a custom one you can specify, but merging xml seems like a hassle and I don't see much benefit there.